### PR TITLE
Példa Pipeline

### DIFF
--- a/.github/workflows/alap.yaml
+++ b/.github/workflows/alap.yaml
@@ -17,7 +17,8 @@ on:
 # Fő feladat
 jobs:
   # Egyszerű build feladat
-  build:
+  learn:
+    name: Példa Pipeline
     # Milyen operációs rendszeren futtassuk a workflow-t
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/alap.yaml` file. The change renames the `build` job to `learn` and adds a name to the job.

* [`.github/workflows/alap.yaml`](diffhunk://#diff-a722b6e545a352186b38f2d1eee4aee4f06282b3b3e89f47bb1ab5cc1d4d4c99L20-R21): Renamed the `build` job to `learn` and added the name "Példa Pipeline" to the job.